### PR TITLE
PAS-132: Return create/update responses for all documents

### DIFF
--- a/src/operators/CourseOperations.ts
+++ b/src/operators/CourseOperations.ts
@@ -9,7 +9,7 @@ export const create = async (course: CourseInterface) => {
 		const hashKey = uuidv4();
 		course.id = hashKey;
 
-		await Course.create(course);
+		return await Course.create(course);
 	} catch (err) {
 		throw new Error('Failed to create course with id ' + course.id);
 	}
@@ -39,7 +39,7 @@ export const update = async (
 			const isOwner = await checkCourseUser(key, userID);
 
 			if (isOwner) {
-				await Course.update(data);
+				return await Course.update(data);
 			} else {
 				throw new Error();
 			}

--- a/src/operators/CourseOperations.ts
+++ b/src/operators/CourseOperations.ts
@@ -9,7 +9,7 @@ export const create = async (course: CourseInterface) => {
 		const hashKey = uuidv4();
 		course.id = hashKey;
 
-		return await Course.create(course);
+		return Course.create(course);
 	} catch (err) {
 		throw new Error('Failed to create course with id ' + course.id);
 	}

--- a/src/operators/UserOperations.ts
+++ b/src/operators/UserOperations.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 export const create = async (user: UserInterface) => {
 	user.id = uuidv4();
-	User.create(user);
+	return await User.create(user);
 };
 
 export const read = async (key: string) => {

--- a/src/operators/UserOperations.ts
+++ b/src/operators/UserOperations.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 export const create = async (user: UserInterface) => {
 	user.id = uuidv4();
-	return await User.create(user);
+	return User.create(user);
 };
 
 export const read = async (key: string) => {

--- a/src/operators/courseItemOperations.ts
+++ b/src/operators/courseItemOperations.ts
@@ -8,7 +8,7 @@ export const create = async (courseItem: CourseItemInterface) => {
 	try {
 		const hashKey = uuidv4();
 		courseItem.id = hashKey;
-		await CourseItem.create(courseItem);
+		return await CourseItem.create(courseItem);
 	} catch {
 		throw new Error('ERROR: could not create courseItem');
 	}
@@ -37,7 +37,7 @@ export const update = async (
 			const key = data.id;
 			const isOwner = await checkCourseItemUser(key, userID);
 			if (isOwner) {
-				await CourseItem.update(data);
+				return await CourseItem.update(data);
 			} else {
 				throw new Error("ERROR: userID doesn't match");
 			}
@@ -52,7 +52,6 @@ export const del = async (key: string, userID: string) => {
 		const isOwner = await checkCourseItemUser(key, userID);
 		if (isOwner) {
 			await CourseItem.delete(key);
-			console.log('Deletion of document with id ' + key + ' successful.');
 		} else {
 			throw new Error("ERROR: userID doesn't match");
 		}

--- a/src/operators/courseItemOperations.ts
+++ b/src/operators/courseItemOperations.ts
@@ -8,7 +8,7 @@ export const create = async (courseItem: CourseItemInterface) => {
 	try {
 		const hashKey = uuidv4();
 		courseItem.id = hashKey;
-		return await CourseItem.create(courseItem);
+		return CourseItem.create(courseItem);
 	} catch {
 		throw new Error('ERROR: could not create courseItem');
 	}
@@ -37,7 +37,7 @@ export const update = async (
 			const key = data.id;
 			const isOwner = await checkCourseItemUser(key, userID);
 			if (isOwner) {
-				return await CourseItem.update(data);
+				return CourseItem.update(data);
 			} else {
 				throw new Error("ERROR: userID doesn't match");
 			}

--- a/src/operators/semesterOperations.ts
+++ b/src/operators/semesterOperations.ts
@@ -8,9 +8,8 @@ export const create = async (semester: SemesterInterface) => {
 	try {
 		const hashKey = uuidv4();
 		semester.id = hashKey;
-		await Semester.create(semester);
+		return await Semester.create(semester);
 	} catch (err) {
-		console.log(err);
 		throw new Error('ERROR: semester not created');
 	}
 };
@@ -29,16 +28,15 @@ export const update = async (
 	data: Partial<SemesterInterface>,
 	userID: string
 ) => {
-	let updated = false;
-	if (data.id) {
-		const key = data.id;
-		const isOwner = await checkSemesterUser(key, userID);
-		const semester = await Semester.get(key);
-		if (isOwner && semester && (await Semester.update(data))) {
-			updated = true;
+	try {
+		if (data.id) {
+			const key = data.id;
+			const isOwner = await checkSemesterUser(key, userID);
+			if (isOwner) {
+				return await Semester.update(data);
+			}
 		}
-	}
-	if (!updated) {
+	} catch (err) {
 		throw new Error('ERROR: semester not updated');
 	}
 };
@@ -49,12 +47,10 @@ export const del = async (key: string, userID: string) => {
 		const semester = await Semester.get(key);
 		if (isOwner && semester) {
 			await Semester.delete(key);
-			console.log('Deletion of document with id ' + key + ' successful.');
 		} else {
 			throw new Error('UserID invalid.');
 		}
 	} catch (err) {
-		console.log(err);
 		throw new Error('ERROR: semester not deleted');
 	}
 };

--- a/src/operators/semesterOperations.ts
+++ b/src/operators/semesterOperations.ts
@@ -8,7 +8,7 @@ export const create = async (semester: SemesterInterface) => {
 	try {
 		const hashKey = uuidv4();
 		semester.id = hashKey;
-		return await Semester.create(semester);
+		return Semester.create(semester);
 	} catch (err) {
 		throw new Error('ERROR: semester not created');
 	}
@@ -33,7 +33,7 @@ export const update = async (
 			const key = data.id;
 			const isOwner = await checkSemesterUser(key, userID);
 			if (isOwner) {
-				return await Semester.update(data);
+				return Semester.update(data);
 			}
 		}
 	} catch (err) {

--- a/src/routers/course.ts
+++ b/src/routers/course.ts
@@ -36,9 +36,8 @@ courseRouter.post('/', async (req, res) => {
 				owner: userID,
 				name: req.body.name,
 			});
-			await create(course);
-			console.log('Post Course');
-			res.send('Post courseRouter: ' + req.body.name);
+			const created = await create(course);
+			res.json(created);
 		}
 	} catch (err) {
 		res.status(404).send('Not found.');
@@ -53,9 +52,8 @@ courseRouter.put('/', async (req, res) => {
 				id: req.body.id,
 				name: req.body.name,
 			});
-			await update(course, userID);
-			console.log('Put Course');
-			res.send('Put courseRouter');
+			const updated = await update(course, userID);
+			res.json(updated);
 		}
 	} catch (err) {
 		res.status(404).send('Not found.');
@@ -68,7 +66,6 @@ courseRouter.delete('/', async (req, res) => {
 
 		if (userID) {
 			await del(req.body.id, userID);
-			console.log('Delete Course');
 			res.send('Delete courseRouter');
 		}
 	} catch (err) {

--- a/src/routers/courseItem.ts
+++ b/src/routers/courseItem.ts
@@ -8,12 +8,10 @@ const ERROR_RESPONSE = 'Course item not found.';
 
 cItemRouter.get('/:id', async (req, res) => {
 	try {
-		console.log('Get course Item');
 		const id = req.params.id;
 		const userID = req.header('userID');
 		if (id && userID) {
 			const courseItem = await read(id, userID);
-			console.log(courseItem);
 			res.send(courseItem);
 		} else {
 			throw 'ERROR - id undefined';
@@ -54,9 +52,8 @@ cItemRouter.post('/', async (req, res) => {
 				createdAt: body.createdAt,
 				updatedAt: body.updatedAt,
 			});
-			await create(courseItem);
-			console.log('Post Course Item');
-			res.send('Post cItemRouter: ' + req.body.name);
+			const created = await create(courseItem);
+			res.json(created);
 		}
 	} catch (err) {
 		res.status(404).send(ERROR_RESPONSE);
@@ -68,7 +65,6 @@ cItemRouter.put('/', async (req, res) => {
 		const userID = req.header('userID');
 		if (userID) {
 			const body = req.body;
-			console.log('updating course item with id ' + body.id);
 			const name = body.name;
 			const weight = numberify(body.weight);
 			const grade = numberify(body.grade);
@@ -80,9 +76,8 @@ cItemRouter.put('/', async (req, res) => {
 				...(grade ? { grade } : {}),
 				...(date ? { date } : {}),
 			});
-			await update(courseItem, userID);
-			console.log('Put Course Item');
-			res.send('Put cItemRouter');
+			const updated = await update(courseItem, userID);
+			res.json(updated);
 		}
 	} catch (err) {
 		res.status(404).send(ERROR_RESPONSE);
@@ -94,7 +89,6 @@ cItemRouter.delete('/', async (req, res) => {
 		const userID = req.header('userID');
 		if (userID) {
 			await del(req.body.id, userID);
-			console.log('Delete Course Item');
 			res.send('Delete cItemRouter');
 		}
 	} catch (err) {

--- a/src/routers/semester.ts
+++ b/src/routers/semester.ts
@@ -8,7 +8,6 @@ const ERROR_RESPONSE = 'Semester not found.';
 
 semesterRouter.get('/:id', async (req, res) => {
 	try {
-		console.log('Get Semester');
 		const userID = req.header('userID');
 		if (userID) {
 			const semester = await read(req.params.id, userID);
@@ -30,11 +29,10 @@ semesterRouter.post('/', async (req, res) => {
 			const semester = new Semester({
 				owner: userID,
 				name: req.body.name,
+				courseItems: [],
 			});
-			console.log('model built');
-			await create(semester);
-			console.log('Put Semester');
-			res.send(req.body.name + ' created successfully');
+			const created = await create(semester);
+			res.json(created);
 		}
 	} catch (err) {
 		res.status(404).send(ERROR_RESPONSE);
@@ -51,9 +49,8 @@ semesterRouter.put('/', async (req, res) => {
 				owner: userID,
 				name: body.name,
 			});
-			await update(semester, userID);
-			console.log('Post Semester');
-			res.send('Semester updated');
+			const updated = await update(semester, userID);
+			res.json(updated);
 		}
 	} catch (err) {
 		res.status(404).send(ERROR_RESPONSE);
@@ -65,7 +62,6 @@ semesterRouter.delete('/', async (req, res) => {
 		const userID = req.header('userID');
 		if (userID) {
 			await del(req.body.id, userID);
-			console.log('Delete Semester');
 			res.send('Semester deleted');
 		}
 	} catch (err) {

--- a/src/routers/user.ts
+++ b/src/routers/user.ts
@@ -20,8 +20,8 @@ userRouter.get('/', async (req, res) => {
 
 userRouter.post('/', async (req, res) => {
 	try {
-		await create(req.body);
-		res.send('User Created');
+		const created = await create(req.body);
+		res.json(created);
 	} catch (e) {
 		res.status(404).send(userError);
 		console.error(`Error: ${e} - Status Code ${res.statusCode}`);
@@ -34,8 +34,8 @@ userRouter.put('/', async (req, res) => {
 		if (!userID) {
 			throw new Error('ERROR: No user ID found.');
 		}
-		await update(req.body, userID);
-		res.send('User posted');
+		const updated = await update(req.body, userID);
+		res.json(updated);
 	} catch (e) {
 		res.status(404).send(userError);
 		console.error(`Error: ${e} - Status Code ${res.statusCode}`);


### PR DESCRIPTION
In a previous ticket I wasn't aware of the importance of returning the result of creating and updating documents, so this fixes that issue by returning the created/updated document in each API response.